### PR TITLE
Fix inline image extraction bug

### DIFF
--- a/src/__tests__/extractInlineImages.js
+++ b/src/__tests__/extractInlineImages.js
@@ -1,0 +1,13 @@
+const { extractInlineImages } = require('../../utils')
+
+describe('extractInlineImages', () => {
+  it('handles nodes without frontmatter', () => {
+    const node = {
+      rawMarkdownBody: "<img src='/img/foo.jpg' />",
+      fileAbsolutePath: __filename,
+    }
+    const result = extractInlineImages(node)
+    expect(Array.isArray(result)).toBe(true)
+    expect(result.length).toBe(1)
+  })
+})

--- a/utils.js
+++ b/utils.js
@@ -43,8 +43,10 @@ function findMd(input) {
 
 exports.extractInlineImages = (node) => {
   const { rawMarkdownBody: html } = node
-  const mdKeys = node.frontmatter && node.frontmatter ? _.flatMapDeep(findMd(node.frontmatter), (i) => i).filter((i) => i) : null
-  if (!mdKeys && !html) {
+  const mdKeys = node.frontmatter
+    ? _.flatMapDeep(findMd(node.frontmatter), (i) => i).filter((i) => i)
+    : []
+  if (!mdKeys.length && !html) {
     return []
   }
   const regex = new RegExp(/(\/img\/.+\.(jp(e)?g|png))/gm)


### PR DESCRIPTION
## Summary
- handle missing frontmatter in extractInlineImages
- add regression test

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7ec4fa8832d94664a3250f2d718