### PR TITLE
fix: correct typo in cms utils test description

### DIFF
--- a/src/cms/__tests__/utils.js
+++ b/src/cms/__tests__/utils.js
@@ -1,6 +1,6 @@
 import { toHTML, findImgPath } from '../utils'
 
-describe('toHMTL', () => {
+describe('toHTML', () => {
   it('takes a markdown string and creates html', () => {
     expect(toHTML('## foobar')).toBe('<h2>foobar</h2>\n')
   })


### PR DESCRIPTION
## Summary
- fix a typo in cms utils test description

## Testing
- `yarn test` *(fails: package not present in lockfile)*
- `yarn install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6851bc56e618832d8a8e97a52cfea1cc